### PR TITLE
Encode scaling of FixedPoint image types

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,6 +26,13 @@ include("unu-make.jl")
         @test img == imgc
         @test axisnames(imgc) == axisnames(img)
         @test axisvalues(imgc) == axisvalues(img)
+        # Check that FixedPoint types get properly encoded
+        outname = joinpath(writedir, "small14.nrrd")
+        img = rand(Gray{N2f14}, 5, 5, 2)
+        save(outname, img)
+        imgr = load(outname)
+        @test eltype(imgr) == Gray{N2f14}
+        @test imgr == img
     end
 
     @testset "Units" begin
@@ -84,6 +91,10 @@ include("unu-make.jl")
             img = load(fn)
             @test eltype(img) == elty
             @test size(img) == (3,5)
+            outname = joinpath(writedir, "elt.nrrd")
+            save(outname, img)
+            imgr = load(outname)
+            @test eltype(imgr) == elty
         end
     end
 


### PR DESCRIPTION
While reader support was added, writer support was missing. This will annotate the header for an `N2f14` array with
```
sample units: gray 16383
```
and that will cause it to be reloaded as a `Gray{N2f14}` array.
