### PR TITLE
Fix writing of AxisArrays with time axis and no unitful dimensions

### DIFF
--- a/src/NRRD.jl
+++ b/src/NRRD.jl
@@ -396,7 +396,7 @@ function headerinfo(T, axs)
         end
         origin = map(x->isa(x, Quantity) ? ustrip(x) : x, map(first, rng))
         if any(x->x!=0, origin)
-            header["space origin"] = [origin...]
+            header["space origin"] = [origin[[isspace...]]...]
         end
     end
     # Adjust the axes for color
@@ -1179,9 +1179,11 @@ function find_datafile(s::Stream{format"NRRD"}, header; mode="r")
     find_datafile(stream(s), header; mode=mode)
 end
 
-nrrd_write{C<:Colorant}(io, A::AbstractArray{C}) = nrrd_write(io, channelview(A))
-nrrd_write{T<:Fixed}(io, A::AbstractArray{T}) = nrrd_write(io, rawview(A))
-nrrd_write(io, A::AbstractArray) = write(io, A)
+nrrd_write(io, A::AxisArray) = nrrd_write(io, A.data)
+nrrd_write(io, A::AbstractArray) = nrrd_write_elty(io, A)
+nrrd_write_elty{C<:Colorant}(io, A::AbstractArray{C}) = nrrd_write_elty(io, channelview(A))
+nrrd_write_elty{T<:Fixed}(io, A::AbstractArray{T}) = nrrd_write_elty(io, rawview(A))
+nrrd_write_elty(io, A::AbstractArray) = write(io, A)
 
 function numberparse(str)
     lstr = lowercase(str)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -70,6 +70,10 @@ include("unu-make.jl")
         @test img == imgc
         @test axisnames(img)[4] == axisnames(imgc)[4] == :time
         @test axisvalues(img) == axisvalues(imgc)
+        img = AxisArray(rand(N0f8, 6, 5, 3, 2), :x, :y, :z, :time)
+        save(outname, img)
+        imgr = load(outname)
+        @test axisnames(imgr)[4] == :time
     end
 
     @testset "eltype" begin


### PR DESCRIPTION
"space origin" had one extra entry corresponding to the time axis