### PR TITLE
Cjg/header only

### DIFF
--- a/src/NRRD.jl
+++ b/src/NRRD.jl
@@ -288,7 +288,7 @@ function save{T}(io::Stream{format"NRRD"}, img::AbstractArray{T}; props::Dict = 
     if isempty(datafilename)
         nrrd_write(io, img)
     else
-        println(sheader, "data file: ", datafilename)
+        println(io, "data file: ", datafilename)
         if !get(props, "headeronly", false)
             open(datafilename, "w") do file
                 nrrd_write(file, img)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -126,6 +126,18 @@ include("unu-make.jl")
         end
     end
 
+    @testset "Header only" begin
+        img = load(joinpath(dirname(@__FILE__), "io", "small.nrrd"))
+        outname = joinpath(writedir, "small.nhdr")
+        isfile(outname) && rm(outname)
+        props = Dict("datafile"=>joinpath(writedir,"small.raw"))
+        save(outname, img; props=props)
+        imgc = load(outname)
+        @test img == imgc
+        @test axisnames(imgc) == axisnames(img)
+        @test axisvalues(imgc) == axisvalues(img)
+    end
+
     gc()  # to close any mmapped files
     try
         rm(workdir, recursive=true)


### PR DESCRIPTION
After a name change we could no longer write header and datafile separately by specifying `datafile`.  Fixes that and adds a test.