### PR TITLE
Apply more exclusions with regards to header fields when writing

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,2 @@
 SimpleTraits
-ImageMetadata
+ImageMetadata 0.5.2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -146,8 +146,7 @@ include("unu-make.jl")
         @test img == imgc
 
         # With units
-        img = AxisArray(rand(N0f16, 5, 7), (:y, :x), (1.0u"mm", 1.2u"mm"))
-        outname = joinpath(writedir, "imagemeta.nhdr")
+        img = AxisArray(img, (:y, :x), (1.0u"mm", 1.2u"mm"))
         save(outname, img)
         imgc = load(outname)
         @test img == imgc

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -144,6 +144,20 @@ include("unu-make.jl")
         save(outname, img)
         imgc = load(outname)
         @test img == imgc
+
+        # With units
+        img = AxisArray(rand(N0f16, 5, 7), (:y, :x), (1.0u"mm", 1.2u"mm"))
+        outname = joinpath(writedir, "imagemeta.nhdr")
+        save(outname, img)
+        imgc = load(outname)
+        @test img == imgc
+        @test pixelspacing(imgc) == (1.0u"mm", 1.2u"mm")
+        img = ImageMeta(img, info=false)
+        save(outname, img)
+        imgc = load(outname)
+        @test img == imgc
+        @test AxisArrays.HasAxes(img) isa AxisArrays.HasAxes{true}
+        @test pixelspacing(imgc) == (1.0u"mm", 1.2u"mm")
     end
 
     GC.gc()  # to close any mmapped files


### PR DESCRIPTION
In https://github.com/timholy/ANTsRegistration.jl I'm finding that the ITK reader ~~doesn't support "basic" fields very well, so it seems better to use the "per-axis" variants by default~~ objects if some fields are written, so be more exclusive.

Breaking change.