### PR TITLE
Fix division by zero error when a dim is size 1

### DIFF
--- a/src/NRRD.jl
+++ b/src/NRRD.jl
@@ -291,7 +291,7 @@ function save(io::Stream{format"NRRD"}, img::AbstractArray{T}; props::Dict = Dic
     for (k, v) in props
         header[k] = v
     end
-    v = version(header, !(keyvals==nothing || isempty(keyvals)))
+    v = version(header, !(keyvals === nothing || isempty(keyvals)))
     write_header(io, v, header, keyvals, comments)
     datafilename = get(props, "datafile", "")
     if isempty(datafilename)
@@ -956,18 +956,19 @@ function write_header(io::IO, version, header, keyvals=nothing, comments=nothing
             println(io, "")
         end
     end
-    if keyvals != nothing
+    if keyvals !== nothing
         for (k,v) in keyvals
             println(io, k, ":=", v)
         end
     end
-    if comments != nothing
+    if comments !== nothing
         for c in comments
             println(io, "# ", c)
         end
     end
+
     println(io)
-    nothing
+    return nothing
 end
 write_header(s::Stream{format"NRRD"}, args...) = write_header(stream(s), args...)
 
@@ -1212,7 +1213,7 @@ function find_datafile(iodata::IOStream, header; mode="r", path=nothing)
     if haskey(header, "data file") || haskey(header, "datafile")
         # Separate header and data files
         fdata = haskey(header, "data file") ? header["data file"] : header["datafile"]
-        if path == nothing
+        if path === nothing
             # Check current directory first
             if isfile(fdata)
                 iodata = open(fdata)

--- a/src/NRRD.jl
+++ b/src/NRRD.jl
@@ -1084,6 +1084,9 @@ function startstoplen(min::Integer, max::Integer, len::Integer)
 end
 
 function startstoplen(min, max, len)
+    if max-min ≈ len-1
+        return min:max
+    end
     stepval = (max-min)/(len-1)
     startstopsteplen(min, max, stepval, len)
 end


### PR DESCRIPTION
When one of the sizes in the header is 1, `startstoplen` divides by 0. An example  header: 

```
...
dimension: 4
space: right-anterior-superior
sizes: 64 128 128 1
space directions: none (-0.12,0,0) (0,0,0.12) (0,0.12,0)
kinds: list domain domain domain
...
```

I ended up replacing `startstep/startstop` altogether in favour of `Base.range`. 